### PR TITLE
Removes semicolon, not last character of cookie

### DIFF
--- a/modules/co2-sqlmapper/src/com/professionallyevil/co2/sqlmapper/SQLMapperForm.java
+++ b/modules/co2-sqlmapper/src/com/professionallyevil/co2/sqlmapper/SQLMapperForm.java
@@ -397,7 +397,7 @@ public class SQLMapperForm implements ClipboardOwner, ActionListener, DocumentLi
             body.deleteCharAt(body.length() - 1);
         }
         if (cookies.length() > 1) {
-            cookies.deleteCharAt(cookies.length() - 2);
+            cookies.deleteCharAt(cookies.length() - 1); //Delete trailing semicolon
         }
         dataTxt.setText(body.toString());
         chkIncludeData.setSelected(dataTxt.getText().length() > 0);


### PR DESCRIPTION
Fixes bug introduced in commit de8074943afcab88e73165cb977e457d36e84477.
When spaces were removed, the code truncated the last character of the cookie rather than removing the trailing semicolon